### PR TITLE
Potential fix for code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[\s\S]*?>)(?:<!\[CDATA\[[^\]]*\]\]>\s*|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/justicengom/justicengom.github.io/security/code-scanning/2](https://github.com/justicengom/justicengom.github.io/security/code-scanning/2)

To fix the issue, we need to rewrite the regular expression to eliminate the ambiguity caused by overlapping patterns and nested quantifiers. Specifically:
1. Replace `[\s\S]*?` with a more specific pattern that avoids ambiguity.
2. Refactor the alternation (`|`) to ensure that the branches do not overlap in what they can match.

The updated regex will explicitly handle the `<![CDATA[]]>` structure and other content separately, ensuring no ambiguity in matching.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
