### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -21,6 +21,19 @@
   const months = ["Jan.", "Feb.", "March", "April", "May", "June", "July", "Aug.", "Sept.", "Oct.", "Nov.", "Dec."];
   const zeroPad = (n) => (n < 10 ? "0" + n : n);
 
+  const escapeHTML = function (str) {
+    return str.replace(/[&<>"']/g, function (char) {
+      const escapeMap = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
+      };
+      return escapeMap[char];
+    });
+  };
+
   const RFC = function (date) {
     const day = days[date.getDay()].substring(0, 3);
     const paddedDate = zeroPad(date.getDate());
@@ -4678,7 +4691,7 @@ d-references {
       const isException = el.getAttribute("no-toc");
       if (isInTitle || isException) continue;
       // create TOC entry
-      const title = el.textContent;
+      const title = escapeHTML(el.textContent);
       const link = "#" + el.getAttribute("id");
 
       let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";


### PR DESCRIPTION
Potential fix for [https://github.com/justicengom/justicengom.github.io/security/code-scanning/6](https://github.com/justicengom/justicengom.github.io/security/code-scanning/6)

To fix the issue, the text extracted from `el.textContent` should be properly escaped before being inserted into the DOM. Escaping ensures that any special characters in the text are treated as literal text rather than HTML or JavaScript. A utility function can be used to escape the text, replacing characters like `<`, `>`, `&`, and `"` with their corresponding HTML entities.

The fix involves:
1. Adding a utility function to escape HTML special characters.
2. Using this function to sanitize `title` before concatenating it into the `newLine` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
